### PR TITLE
Josh win reset

### DIFF
--- a/src/background.rs
+++ b/src/background.rs
@@ -37,7 +37,8 @@ pub struct Cubbie {
 }
 
 pub struct Cubbies {
-    cubbies: Vec<Cubbie>
+    cubbies: Vec<Cubbie>,
+    filled_cubbies: u32
 }
 
 pub struct Menu {
@@ -105,7 +106,8 @@ impl Cubbie {
 impl Cubbies {
     pub fn construct() -> Cubbies {
         Cubbies {
-            cubbies: Cubbies::create_cubbies()
+            cubbies: Cubbies::create_cubbies(),
+            filled_cubbies: CUB_NUM
         }
     }
 
@@ -135,7 +137,15 @@ impl Cubbies {
 
     pub fn set_is_occupied(&mut self, i: usize) {
         self.cubbies[i].is_occupied = true;
+        self.filled_cubbies -= 1;
     }
+
+    pub fn get_filled_cubbies(&mut self) -> u32 {self.filled_cubbies }
+
+//    pub fn reset_cubbies(&mut self) {
+//        self.cubbies = self.create_cubbies();
+//        self.filled_cubbies = CUB_NUM;
+//    }
 }
 
 impl Menu {

--- a/src/background.rs
+++ b/src/background.rs
@@ -142,10 +142,6 @@ impl Cubbies {
 
     pub fn get_filled_cubbies(&mut self) -> u32 {self.filled_cubbies }
 
-//    pub fn reset_cubbies(&mut self) {
-//        self.cubbies = self.create_cubbies();
-//        self.filled_cubbies = CUB_NUM;
-//    }
 }
 
 impl Menu {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -53,4 +53,6 @@ pub const MAX_NUM_OF_TURTLES: u32 = MAX_NUM_OF_CARS - 1;
 pub const LOG_W: f32 = TRUCK_W;
 pub const TURTLE_W: f32 = CAR_W;
 
-
+//Game state
+pub const COLLISIONS_ON : bool = false;
+pub const WINNING_CUBBIES : u32 = 5;

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,7 +203,6 @@ impl event::EventHandler for MainState {
         //Check for game over
         if self.player.get_lives() <= 0 || self.cubbies.get_filled_cubbies() == WINNING_CUBBIES {
             let victory = self.cubbies.get_filled_cubbies() == WINNING_CUBBIES;
-            self.player.set_lives();
             //self.cubbies.reset_cubbies();
             self.cubbies = Cubbies::construct();
 
@@ -220,6 +219,7 @@ impl event::EventHandler for MainState {
                 graphics::draw(_ctx, &text, dest_point, 0.0)?;
             }
             else {
+                self.player.set_lives();
                 //Game over has a scalable center, text should always be in center regardless of dimensions
                 let center: f32 = WIN_W as f32 / 2.0 - *&self.game_over_man.width() as f32 / 2.0;
 


### PR DESCRIPTION
It shows a lot of changes since the code shifted down, but here's the basic rundown:

1. I created a constant bool, COLLISIONS_ON, which allows you to turn collisions off.  If you want to test the game out to see what happens when you win, for example, you don't have to actually play the game to the end.

2. Another constant, WINNING_CUBBIES, sets how many cubbies you need to fill (or rather how many can be left empty) before you win.  That way, again, if you want to see a win, you don't have to actually fill all the cubbies.  Right now, it's set to 5, so you only need to fill a single cubbie to win.

3. I added an if statement to game over to check and see if the game ended because you won or lost.  If you won, a "Win!" message displays instead of "Game over!", the board still resets, but you keep your score.